### PR TITLE
Perfil Read-Only promotor

### DIFF
--- a/force-app/main/default/applications/CRM_SOLDIT_HOMES.app-meta.xml
+++ b/force-app/main/default/applications/CRM_SOLDIT_HOMES.app-meta.xml
@@ -1,33 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomApplication xmlns="http://soap.sforce.com/2006/04/metadata">
-    <actionOverrides>
-        <actionName>Tab</actionName>
-        <content>DDS_SH</content>
-        <formFactor>Large</formFactor>
-        <skipRecordTypeSelect>false</skipRecordTypeSelect>
-        <type>Flexipage</type>
-        <pageOrSobjectType>standard-home</pageOrSobjectType>
-    </actionOverrides>
-    <actionOverrides>
-        <actionName>View</actionName>
-        <comment>Action override created by Lightning App Builder during activation.</comment>
-        <content>Factura_Record_Page1</content>
-        <formFactor>Large</formFactor>
-        <skipRecordTypeSelect>false</skipRecordTypeSelect>
-        <type>Flexipage</type>
-        <pageOrSobjectType>Factura__c</pageOrSobjectType>
-    </actionOverrides>
     <brand>
         <headerColor>#144E81</headerColor>
-        <logo>Logo_BN_1</logo>
-        <logoVersion>1</logoVersion>
         <shouldOverrideOrgTheme>false</shouldOverrideOrgTheme>
     </brand>
     <formFactors>Large</formFactors>
     <isNavAutoTempTabsDisabled>false</isNavAutoTempTabsDisabled>
     <isNavPersonalizationDisabled>false</isNavPersonalizationDisabled>
+    <isNavTabPersistenceDisabled>false</isNavTabPersistenceDisabled>
     <label>CRM SOLDIT HOMES</label>
     <navType>Standard</navType>
+    <profileActionOverrides>
+        <actionName>Tab</actionName>
+        <content>DDS_SH</content>
+        <formFactor>Large</formFactor>
+        <pageOrSobjectType>standard-home</pageOrSobjectType>
+        <type>Flexipage</type>
+        <profile>Comercial API</profile>
+    </profileActionOverrides>
     <tabs>standard-home</tabs>
     <tabs>standard-report</tabs>
     <tabs>standard-Lead</tabs>
@@ -52,6 +42,10 @@
     <tabs>DocumentCategory__c</tabs>
     <tabs>Factura_devuelta__c</tabs>
     <tabs>VentasSemanales__c</tabs>
+    <tabs>Mejora__c</tabs>
+    <tabs>MejorasTiposInmueble__c</tabs>
+    <tabs>MejorasViviendas__c</tabs>
+    <tabs>MejoraOportunidad__c</tabs>
     <uiType>Lightning</uiType>
     <utilityBar>CRM_SOLDIT_HOMES_UtilityBar</utilityBar>
 </CustomApplication>

--- a/force-app/main/default/groups/ReadOnlyPromotor.group-meta.xml
+++ b/force-app/main/default/groups/ReadOnlyPromotor.group-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Group xmlns="http://soap.sforce.com/2006/04/metadata">
+    <doesIncludeBosses>true</doesIncludeBosses>
+    <name>Read Only - Promotor</name>
+</Group>

--- a/force-app/main/default/profiles/Read Only Promotor.profile-meta.xml
+++ b/force-app/main/default/profiles/Read Only Promotor.profile-meta.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Profile xmlns="http://soap.sforce.com/2006/04/metadata">
+    <applicationVisibilities>
+        <application>CRM_SOLDIT_HOMES</application>
+        <default>true</default>
+        <visible>true</visible>
+    </applicationVisibilities>
+    <custom>true</custom>
+    <description>Perfil para los usuarios Promotores con capacidad de leer Dashboards</description>
+    <userLicense>Salesforce</userLicense>
+    <userPermissions>
+        <enabled>true</enabled>
+        <name>ActivitiesAccess</name>
+    </userPermissions>
+    <userPermissions>
+        <enabled>true</enabled>
+        <name>ApiEnabled</name>
+    </userPermissions>
+    <userPermissions>
+        <enabled>true</enabled>
+        <name>ChatterInternalUser</name>
+    </userPermissions>
+    <userPermissions>
+        <enabled>true</enabled>
+        <name>LightningConsoleAllowedForUser</name>
+    </userPermissions>
+    <userPermissions>
+        <enabled>true</enabled>
+        <name>RunReports</name>
+    </userPermissions>
+    <userPermissions>
+        <enabled>true</enabled>
+        <name>ViewHelpLink</name>
+    </userPermissions>
+</Profile>


### PR DESCRIPTION
Crear un perfil con permisos mínimos. Solo acceso a Dashboards, reports y pocos objetos visibles (oportunidades, leads, promocion y productos).

Crear el grupo público para compartir dashboards con dicho perfil

Modificada la app CRM SH para añadir el perfil